### PR TITLE
Replace use of pkg_resources with importlib

### DIFF
--- a/pymt_permamodel/__init__.py
+++ b/pymt_permamodel/__init__.py
@@ -1,7 +1,7 @@
 #! /usr/bin/env python
-import pkg_resources
+from importlib.metadata import version
 
-__version__ = pkg_resources.get_distribution("pymt_permamodel").version
+__version__ = version("pymt_permamodel")
 
 
 from .bmi import FrostNumber, Ku, KuEnhanced

--- a/pymt_permamodel/bmi.py
+++ b/pymt_permamodel/bmi.py
@@ -1,16 +1,32 @@
 from __future__ import absolute_import
 
-import pkg_resources
+import sys
+import importlib
+import pathlib
+
 from permamodel.components.bmi_frost_number import BmiFrostnumberMethod as FrostNumber
 from permamodel.components.bmi_Ku import BmiKuModel as KuEnhanced
 from permamodel.components.bmi_Ku_component import BmiKuMethod as Ku
 
+if sys.version_info >= (3, 12):  # pragma: no cover (PY12+)
+    import importlib.resources as importlib_resources
+else:  # pragma: no cover (<PY312)
+    import importlib_resources
+
 FrostNumber.__name__ = "FrostNumber"
-FrostNumber.METADATA = pkg_resources.resource_filename(__name__, "data/FrostNumber")
+FrostNumber.METADATA = pathlib.Path(
+    importlib_resources.files(__name__) / "data" / FrostNumber.__name__
+)
+
 Ku.__name__ = "Ku"
-Ku.METADATA = pkg_resources.resource_filename(__name__, "data/Ku")
+Ku.METADATA = pathlib.Path(
+    importlib_resources.files(__name__) / "data" / Ku.__name__
+)
+
 KuEnhanced.__name__ = "KuEnhanced"
-KuEnhanced.METADATA = pkg_resources.resource_filename(__name__, "data/KuEnhanced")
+KuEnhanced.METADATA = pathlib.Path(
+    importlib_resources.files(__name__) / "data" / KuEnhanced.__name__
+)
 
 __all__ = [
     "FrostNumber",

--- a/pymt_permamodel/bmi.py
+++ b/pymt_permamodel/bmi.py
@@ -1,7 +1,7 @@
 from __future__ import absolute_import
 
-import sys
 import pathlib
+import sys
 
 from permamodel.components.bmi_frost_number import BmiFrostnumberMethod as FrostNumber
 from permamodel.components.bmi_Ku import BmiKuModel as KuEnhanced
@@ -18,9 +18,7 @@ FrostNumber.METADATA = pathlib.Path(
 )
 
 Ku.__name__ = "Ku"
-Ku.METADATA = pathlib.Path(
-    importlib_resources.files(__name__) / "data" / Ku.__name__
-)
+Ku.METADATA = pathlib.Path(importlib_resources.files(__name__) / "data" / Ku.__name__)
 
 KuEnhanced.__name__ = "KuEnhanced"
 KuEnhanced.METADATA = pathlib.Path(

--- a/pymt_permamodel/bmi.py
+++ b/pymt_permamodel/bmi.py
@@ -1,7 +1,6 @@
 from __future__ import absolute_import
 
 import sys
-import importlib
 import pathlib
 
 from permamodel.components.bmi_frost_number import BmiFrostnumberMethod as FrostNumber


### PR DESCRIPTION
This PR includes minor changes resulting from replacing the deprecated _pkg_resources_ library with [importlib.resources](https://docs.python.org/3.13/library/importlib.resources.html#module-importlib.resources) and [importlib.metadata](https://docs.python.org/3.13/library/importlib.metadata.html#module-importlib.metadata).